### PR TITLE
Changed repo addresses on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
   "version": "1.9.2-2",
   "repository": {
     "type": "git",
-    "url": "https://github.com/sandeepmistry/noble.git"
+    "url": "https://github.com/abandonware/noble/noble.git"
   },
   "bugs": {
-    "url": "https://github.com/sandeepmistry/noble/issues"
+    "url": "https://github.com/abandonware/noble/issues"
   },
   "keywords": [
     "bluetooth",


### PR DESCRIPTION
The address was still pointing to the old repo which gets used on npm when you publish it also.